### PR TITLE
Implementing IIonReader Interface Changes from Ion

### DIFF
--- a/Amazon.IonHashDotnet.Tests/IonHashDataSource.cs
+++ b/Amazon.IonHashDotnet.Tests/IonHashDataSource.cs
@@ -45,7 +45,7 @@ namespace Amazon.IonHashDotnet.Tests
                     testName = testCase.GetField("ion").ToPrettyString();
                 }
 
-                IReadOnlyCollection<SymbolToken> annotations = testCase.GetTypeAnnotations();
+                IReadOnlyCollection<SymbolToken> annotations = testCase.GetTypeAnnotationSymbols();
                 if (annotations.Count > 0)
                 {
                     testName = annotations.ElementAt(0).Text;

--- a/Amazon.IonHashDotnet.Tests/IonHashTest.cs
+++ b/Amazon.IonHashDotnet.Tests/IonHashTest.cs
@@ -24,7 +24,6 @@ namespace Amazon.IonHashDotnet.Tests
     using Amazon.IonDotnet.Builders;
     using Amazon.IonDotnet.Tree;
     using Amazon.IonDotnet.Tree.Impl;
-    using Amazon.IonHashDotnet;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -141,7 +140,7 @@ namespace Amazon.IonHashDotnet.Tests
             while (enumerator.MoveNext())
             {
                 IIonValue v = enumerator.Current;
-                foreach (SymbolToken annotation in v.GetTypeAnnotations())
+                foreach (SymbolToken annotation in v.GetTypeAnnotationSymbols())
                 {
                     methodCalls.Add(annotation.Text);
                 }
@@ -162,7 +161,7 @@ namespace Amazon.IonHashDotnet.Tests
                 while (enumerator.MoveNext())
                 {
                     IIonValue v = enumerator.Current;
-                    String methodCall = v.GetTypeAnnotations().ElementAt(0).Text;
+                    String methodCall = v.GetTypeAnnotationSymbols().ElementAt(0).Text;
                     if (methodCalls.Contains(methodCall))
                     {
                         result.Add(v);
@@ -187,7 +186,7 @@ namespace Amazon.IonHashDotnet.Tests
                     sb.Append("\n  ");
                 }
 
-                foreach (SymbolToken annotation in hashCall.GetTypeAnnotations())
+                foreach (SymbolToken annotation in hashCall.GetTypeAnnotationSymbols())
                 {
                     sb.Append(annotation.Text).Append("::");
                 }

--- a/Amazon.IonHashDotnet.Tests/ReaderCompare.cs
+++ b/Amazon.IonHashDotnet.Tests/ReaderCompare.cs
@@ -45,6 +45,8 @@ namespace Amazon.IonHashDotnet.Tests
                 }
 
                 CompareAnnotations(it1, it2);
+                CompareAnnotationSymbols(it1, it2);
+                CompareHasAnnotations(it1, it2);
 
                 bool isNull = it1.CurrentIsNull;
                 Assert.AreEqual(isNull, it2.CurrentIsNull);
@@ -123,10 +125,32 @@ namespace Amazon.IonHashDotnet.Tests
 
         private static void CompareAnnotations(IIonReader it1, IIonReader it2)
         {
-            SymbolToken[] syms1 = it1.GetTypeAnnotations().ToArray();
-            SymbolToken[] syms2 = it2.GetTypeAnnotations().ToArray();
+            string[] syms_text1 = it1.GetTypeAnnotations();
+            string[] syms_text2 = it2.GetTypeAnnotations();
+
+            Assert.IsTrue(syms_text1.SequenceEqual(syms_text2));
+        }
+
+        private static void CompareAnnotationSymbols(IIonReader it1, IIonReader it2)
+        {
+            SymbolToken[] syms1 = it1.GetTypeAnnotationSymbols().ToArray();
+            SymbolToken[] syms2 = it2.GetTypeAnnotationSymbols().ToArray();
 
             AssertSymbolEquals("annotation", syms1, syms2);
+        }
+
+        private static void CompareHasAnnotations(IIonReader it1, IIonReader it2)
+        {
+            string[] syms_text1 = it1.GetTypeAnnotations();
+            string[] syms_text2 = it2.GetTypeAnnotations();
+
+            Assert.IsTrue(syms_text1.Count() == syms_text2.Count());
+
+            for (int index = 0; index < syms_text1.Count(); index++)
+            {
+                Assert.IsTrue(it1.HasAnnotation(syms_text2[index]));
+                Assert.IsTrue(it2.HasAnnotation(syms_text1[index]));
+            }
         }
 
         private static void CompareScalars(IonType t, bool isNull, IIonReader it1, IIonReader it2)

--- a/Amazon.IonHashDotnet/IonHashReader.cs
+++ b/Amazon.IonHashDotnet/IonHashReader.cs
@@ -36,7 +36,7 @@ namespace Amazon.IonHashDotnet
         // implements IIonHashValue
         public IList<SymbolToken> Annotations
         {
-            get { return this.GetTypeAnnotations().ToList(); }
+            get { return this.GetTypeAnnotationSymbols().ToList(); }
         }
 
         public dynamic CurrentValue
@@ -74,6 +74,14 @@ namespace Amazon.IonHashDotnet
         public byte[] Digest()
         {
             return this.hasher.Digest();
+        }
+
+        /// <summary>
+        /// Dispose the IIonReader
+        /// </summary>
+        public void Dispose()
+        {
+            this.reader.Dispose();
         }
 
         public void StepIn()
@@ -182,9 +190,19 @@ namespace Amazon.IonHashDotnet
             return this.reader.GetBytes(buffer);
         }
 
-        public IEnumerable<SymbolToken> GetTypeAnnotations()
+        public string[] GetTypeAnnotations()
         {
             return this.reader.GetTypeAnnotations();
+        }
+
+        public IEnumerable<SymbolToken> GetTypeAnnotationSymbols()
+        {
+            return this.reader.GetTypeAnnotationSymbols();
+        }
+
+        public bool HasAnnotation(string annotation)
+        {
+            return this.reader.HasAnnotation(annotation);
         }
 
         public byte[] NewByteArray()
@@ -237,14 +255,6 @@ namespace Amazon.IonHashDotnet
                     this.StepOut();
                 }
             }
-        }
-
-        /// <summary>
-        /// Dispose the IIonReader
-        /// </summary>
-        public void Dispose()
-        {
-            this.reader.Dispose();
         }
     }
 }

--- a/Amazon.IonHashDotnet/IonHashWriter.cs
+++ b/Amazon.IonHashDotnet/IonHashWriter.cs
@@ -266,7 +266,7 @@ namespace Amazon.IonHashDotnet
                 }
             }
 
-            foreach (var annotation in reader.GetTypeAnnotations())
+            foreach (var annotation in reader.GetTypeAnnotationSymbols())
             {
                 this.AddTypeAnnotationSymbol(annotation);
             }


### PR DESCRIPTION
*Issue https://github.com/amzn/ion-hash-dotnet/issues/26*

*Description of changes:*
For `IonHashReader`

- Rename the existing `GetTypeAnnotations()` method to `GetTypeAnnotationSymbols()`
- add `string[] GetTypeAnnotations()`
- add `bool HasAnnotation(string annotation)`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
