### PR TITLE
Fix duplicated annotations

### DIFF
--- a/Amazon.IonHashDotnet.Tests/IonHashWriterTest.cs
+++ b/Amazon.IonHashDotnet.Tests/IonHashWriterTest.cs
@@ -81,8 +81,6 @@ namespace Amazon.IonHashDotnet.Tests
 
             ihw.Finish();
 
-            //Commented out following assertion because it is failing
-            //https://github.com/amzn/ion-hash-dotnet/issues/5
             Assert.AreEqual("null [5] null {hello:ion::hash::'world'}", stringWriter.ToString());
         }
 

--- a/Amazon.IonHashDotnet.Tests/IonHashWriterTest.cs
+++ b/Amazon.IonHashDotnet.Tests/IonHashWriterTest.cs
@@ -83,7 +83,7 @@ namespace Amazon.IonHashDotnet.Tests
 
             //Commented out following assertion because it is failing
             //https://github.com/amzn/ion-hash-dotnet/issues/5
-            //Assert.AreEqual("null [5] null {hello:ion::hash::world}", stringWriter);
+            Assert.AreEqual("null [5] null {hello:ion::hash::'world'}", stringWriter.ToString());
         }
 
         [TestMethod]

--- a/Amazon.IonHashDotnet/IonHashWriter.cs
+++ b/Amazon.IonHashDotnet/IonHashWriter.cs
@@ -89,7 +89,6 @@ namespace Amazon.IonHashDotnet
         public void AddTypeAnnotation(string annotation)
         {
             this.AddTypeAnnotationSymbol(new SymbolToken(annotation, SymbolToken.UnknownSid));
-            this.writer.AddTypeAnnotation(annotation);
         }
 
         public void AddTypeAnnotationSymbol(SymbolToken annotation)


### PR DESCRIPTION
IonHashWriterTest - TestMiscMethods test is failing because it is duplicating annotations - Issue #5

*Issue #5 

AddTypeAnnotationSymbol() already contains a write annotation step, removing the duplication. 
