### PR TITLE
Fixed the issue of failing tests with .Net Framework.

### DIFF
--- a/Amazon.IonHashDotnet.Tests/Amazon.IonHashDotnet.Tests.csproj
+++ b/Amazon.IonHashDotnet.Tests/Amazon.IonHashDotnet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>

--- a/Amazon.IonHashDotnet/CryptoIonHasher.cs
+++ b/Amazon.IonHashDotnet/CryptoIonHasher.cs
@@ -40,7 +40,9 @@ namespace Amazon.IonHashDotnet
         public virtual byte[] Digest()
         {
             this.hashAlgorithm.TransformFinalBlock(new byte[0], 0, 0);
-            return this.hashAlgorithm.Hash;
+            var result = this.hashAlgorithm.Hash;
+            this.hashAlgorithm.Initialize();
+            return result;
         }
     }
 }


### PR DESCRIPTION
Force CryptoIonHasher to explicitly re-initialize the hashAlgorithm when calling Digest().

*Issue #, if available:* #43 

*Description of changes:*
- Made the test project running on both .Net Core and .Net Framework
- Fixed the issue reported in #43

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
