### PR TITLE
Remove .Net Core 3.1 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]        # add other OSes later
-        dotnet: ['2.1', '3.1']
+        dotnet: ['2.1']
 
     steps:
       - name: Git Checkout

--- a/Amazon.IonHashDotnet.Tests/Amazon.IonHashDotnet.Tests.csproj
+++ b/Amazon.IonHashDotnet.Tests/Amazon.IonHashDotnet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION


*Description of changes:*

Removes the support for `netcoreapp3.1` for now. I believe that with `netcoreapp2.1` and `net48` we are still covering the original issue addressed by https://github.com/amzn/ion-hash-dotnet/pull/44 

From a quick search online I have found that .Net Core 3.1 is not 100% compatible with .Net Core 2.1 https://github.com/dotnet/aspnetcore/issues/18386

Given that we launched with .Net Core 2.1 my proposal is to remain on .Net Core 2.1 for now. If this decision causes issues then we can bump the version to .Net Core 3.1 but I think we should also bump our library's major version as well. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
