### PR TITLE
Replace Amazon.IonDotnet version reference with wildcard 1.* 

### DIFF
--- a/Amazon.IonHashDotnet.Tests/Amazon.IonHashDotnet.Tests.csproj
+++ b/Amazon.IonHashDotnet.Tests/Amazon.IonHashDotnet.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonDotnet" Version="1.0.0" />
+    <PackageReference Include="Amazon.IonDotnet" Version="1.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/Amazon.IonHashDotnet/Amazon.IonHashDotnet.csproj
+++ b/Amazon.IonHashDotnet/Amazon.IonHashDotnet.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonDotnet" Version="1.0.0" />
+    <PackageReference Include="Amazon.IonDotnet" Version="1.*" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

With the release of `Amazon.IonDotnet` version 1.2.2, we have had customers requesting that we upgrade `Amazon.QLDB.Driver` to use the new version. We depend on `Amazon.IonHashDotnet` as part of that project, and are encountering build errors due to version mismatches.

This change upgrades `Amazon.IonHashDotnet` to use `Amazon.IonDotnet` 1.2.2, which notably includes [a fix to decimal conversion](https://github.com/amzn/ion-dotnet/commit/e13d44f6108fe067495cf5201fa102e9ef35fe8a).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
